### PR TITLE
Translate confirmation email

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,6 +1,6 @@
 plugin.tx_dmailsubscribe {
     view {
-        templateRootPath >
+        layoutRootPath >
         layoutRootPaths.0 = EXT:dmailsubscribe/Resources/Private/Layouts/
         layoutRootPaths.10 = {$plugin.tx_dmailsubscribe.view.layoutRootPath}
 

--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -42,6 +42,13 @@
             <label index="message.unsubscribe.subscription_not_found">This subscription could not be found.</label>
             <label index="message.unsubscribe.success">You have been successfully unsubscribed from our newsletter.
             </label>
+            <label index="email.greeting">Success</label>
+            <label index="email.confirm_link_help">You have been subscribed to our newsletter. Please click the
+                following link to confirm your subscription</label>
+            <label index="email.confirm_link_text">subscription</label>
+            <label index="email.unsubscribe_link_help">To unscubscribe from our newsletter click the following link
+            </label>
+            <label index="email.unsubscribe_link_text">Unsubscribe</label>
         </languageKey>
     </data>
 </T3locallang>

--- a/Resources/Private/Templates/Email/NewSubscription.html
+++ b/Resources/Private/Templates/Email/NewSubscription.html
@@ -5,15 +5,16 @@
 <f:layout name="HtmlEmail"/>
 
 <f:section name="Main">
-    <h1>Success</h1>
+    <h1><f:translate key="email.greeting"/></h1>
 
-    <p>You have been subscribed to our newsletter. Please click the following link to confirm your subscription:
-        <d:link.confirm subscriptionUid="{subscription.uid}" confirmationCode="{confirmationCode}">Confirm
-            subscription
+    <p><f:translate key="email.confirm_link_help"/>:
+        <d:link.confirm subscriptionUid="{subscription.uid}" confirmationCode="{confirmationCode}">
+            <f:translate key="email.confirm_link_text"/>
         </d:link.confirm>
     </p>
-    <p>To unscubscribe from our newsletter click the following link:
-        <d:link.unsubscribe subscriptionUid="{subscription.uid}" confirmationCode="{confirmationCode}">Unsubscribe
+    <p><f:translate key="email.unsubscribe_link_help"/>:
+        <d:link.unsubscribe subscriptionUid="{subscription.uid}" confirmationCode="{confirmationCode}">
+            <f:translate key="email.unsubscribe_link_text"/>
         </d:link.unsubscribe>
     </p>
 </f:section>

--- a/Resources/Private/Templates/Email/NewSubscription.txt
+++ b/Resources/Private/Templates/Email/NewSubscription.txt
@@ -5,11 +5,12 @@
 <f:layout name="PlainEmail" />
 
 <f:section name="Main">
-Success
+<f:translate key="email.greeting"/>
 
-You have been subscribed to our newsletter. Please click the following link
-to confirm your subscription:  <d:uri.confirm subscriptionUid="{subscription.uid}" confirmationCode="{confirmationCode}" />
+<f:translate key="email.confirm_link_help"/>:
+<d:uri.confirm subscriptionUid="{subscription.uid}" confirmationCode="{confirmationCode}" />
 
-To unscubscribe from our newsletter click the following link: <d:uri.unsubscribe subscriptionUid="{subscription.uid}" confirmationCode="{confirmationCode}" />
+<f:translate key="email.unsubscribe_link_help"/>:
+<d:uri.unsubscribe subscriptionUid="{subscription.uid}" confirmationCode="{confirmationCode}" />
 </f:section>
 </html>

--- a/Resources/Private/Templates/Subscription/New.html
+++ b/Resources/Private/Templates/Subscription/New.html
@@ -63,7 +63,7 @@
 
         <div class="form-row">
             <div class="form-label">
-                <label for="email">{f:translate(key: 'label.email')}*</label>
+                <label for="email">{f:translate(key: 'label.email')} *</label>
             </div>
             <div class="form-field">
                 <f:form.textfield id="email" property="email"/>


### PR DESCRIPTION
Hi,
this commits allows to translate the confirmation email and also fixes some small misprint.
I hope it can help.