### PR TITLE
[BUGFIX] Correct signature of render method in AbstractLinkVH

### DIFF
--- a/Classes/ViewHelpers/AbstractLinkViewHelper.php
+++ b/Classes/ViewHelpers/AbstractLinkViewHelper.php
@@ -72,7 +72,7 @@ abstract class AbstractLinkViewHelper extends ActionViewHelper
      * @throws ConfigurationException
      * @return string
      */
-    public function render()
+    public function render($action = null, array $arguments = [], $controller = null, $extensionName = null, $pluginName = null, $pageUid = null, $pageType = 0, $noCache = false, $noCacheHash = false, $section = '', $format = '', $linkAccessRestrictedPages = false, array $additionalParams = [], $absolute = false, $addQueryString = false, array $argumentsToBeExcludedFromQueryString = [], $addQueryStringMethod = null)
     {
         if (null === ($pluginPageUid = $this->settingsService->getSetting('pluginPageUid'))) {
             throw new ConfigurationException('Plugin page Uid is not configured.');

--- a/Classes/ViewHelpers/AbstractLinkViewHelper.php
+++ b/Classes/ViewHelpers/AbstractLinkViewHelper.php
@@ -64,11 +64,29 @@ abstract class AbstractLinkViewHelper extends ActionViewHelper
      */
     public function initializeArguments()
     {
+        parent::initializeArguments();
         $this->registerArgument('subscriptionUid', 'integer', 'Uid of the subscription to confirm.', true);
         $this->registerArgument('confirmationCode', 'string', 'Confirmation code of the subscription to confirm.', true);
     }
 
     /**
+     * @param string $action Target action
+     * @param array $arguments Arguments
+     * @param string $controller Target controller. If NULL current controllerName is used
+     * @param string $extensionName Target Extension Name (without "tx_" prefix and no underscores). If NULL the current extension name is used
+     * @param string $pluginName Target plugin. If empty, the current plugin name is used
+     * @param int $pageUid target page. See TypoLink destination
+     * @param int $pageType type of the target page. See typolink.parameter
+     * @param bool $noCache set this to disable caching for the target page. You should not need this.
+     * @param bool $noCacheHash set this to suppress the cHash query parameter created by TypoLink. You should not need this.
+     * @param string $section the anchor to be added to the URI
+     * @param string $format The requested format, e.g. ".html
+     * @param bool $linkAccessRestrictedPages If set, links pointing to access restricted pages will still link to the page even though the page cannot be accessed.
+     * @param array $additionalParams additional query parameters that won't be prefixed like $arguments (overrule $arguments)
+     * @param bool $absolute If set, the URI of the rendered link is absolute
+     * @param bool $addQueryString If set, the current query parameters will be kept in the URI
+     * @param array $argumentsToBeExcludedFromQueryString arguments to be removed from the URI. Only active if $addQueryString = TRUE
+     * @param string $addQueryStringMethod Set which parameters will be kept. Only active if $addQueryString = TRUE
      * @throws ConfigurationException
      * @return string
      */

--- a/Classes/ViewHelpers/AbstractUriViewHelper.php
+++ b/Classes/ViewHelpers/AbstractUriViewHelper.php
@@ -64,15 +64,33 @@ abstract class AbstractUriViewHelper extends ActionViewHelper
      */
     public function initializeArguments()
     {
+        parent::initializeArguments();
         $this->registerArgument('subscriptionUid', 'integer', 'Uid of the subscription to confirm.', true);
         $this->registerArgument('confirmationCode', 'string', 'Confirmation code of the subscription to confirm.', true);
     }
 
     /**
+     * @param string $action Target action
+     * @param array $arguments Arguments
+     * @param string $controller Target controller. If NULL current controllerName is used
+     * @param string $extensionName Target Extension Name (without "tx_" prefix and no underscores). If NULL the current extension name is used
+     * @param string $pluginName Target plugin. If empty, the current plugin name is used
+     * @param int $pageUid target page. See TypoLink destination
+     * @param int $pageType type of the target page. See typolink.parameter
+     * @param bool $noCache set this to disable caching for the target page. You should not need this.
+     * @param bool $noCacheHash set this to suppress the cHash query parameter created by TypoLink. You should not need this.
+     * @param string $section the anchor to be added to the URI
+     * @param string $format The requested format, e.g. ".html
+     * @param bool $linkAccessRestrictedPages If set, links pointing to access restricted pages will still link to the page even though the page cannot be accessed.
+     * @param array $additionalParams additional query parameters that won't be prefixed like $arguments (overrule $arguments)
+     * @param bool $absolute If set, an absolute URI is rendered
+     * @param bool $addQueryString If set, the current query parameters will be kept in the URI
+     * @param array $argumentsToBeExcludedFromQueryString arguments to be removed from the URI. Only active if $addQueryString = TRUE
+     * @param string $addQueryStringMethod Set which parameters will be kept. Only active if $addQueryString = TRUE
      * @throws ConfigurationException
      * @return string
      */
-    public function render()
+    public function render($action = null, array $arguments = [], $controller = null, $extensionName = null, $pluginName = null, $pageUid = null, $pageType = 0, $noCache = false, $noCacheHash = false, $section = '', $format = '', $linkAccessRestrictedPages = false, array $additionalParams = [], $absolute = false, $addQueryString = false, array $argumentsToBeExcludedFromQueryString = [], $addQueryStringMethod = null)
     {
         if (null === ($pluginPageUid = $this->settingsService->getSetting('pluginPageUid'))) {
             throw new ConfigurationException('Plugin page Uid is not configured.');


### PR DESCRIPTION
Method signatures need to be compatible. If they're not, warnings are raised.
In the worst case, a warning triggers the exception handler.
